### PR TITLE
Fixes to allow CloudTrail and VPC FLow Logs in existing S3 buckets to…

### DIFF
--- a/templates/s3bucketcollection/documentation/Cribl Cloud Trust IAM Role for CloudTrail Access.md
+++ b/templates/s3bucketcollection/documentation/Cribl Cloud Trust IAM Role for CloudTrail Access.md
@@ -73,6 +73,7 @@ The role has an inline policy granting:
 
 1. Deploy this template in your AWS account
 2. Provide the resulting role ARN, SQS queue ARN, and external ID to Cribl Cloud
+    2a. If you use AWS KMS Key encryption for your CloudTrail logs in S3, update the KMS Key policy in the Logging Account to allow Cribl Cloud to decrypt the CloudTrail logs in S3 by deploying the CloudFormation templatte (cribl_kms_key_policy_update.yaml) in your AWS Account that manages your KMS Key for your CloudTrail logs in S3
 3. Configure Cribl Cloud to use these credentials for accessing your CloudTrail logs
 
 This setup enables Cribl Cloud to securely access and process your CloudTrail logs, facilitating advanced log analysis and management capabilities.

--- a/templates/s3bucketcollection/documentation/Cribl Cloud Trust IAM Role for VPC Flow Logs Acces.md
+++ b/templates/s3bucketcollection/documentation/Cribl Cloud Trust IAM Role for VPC Flow Logs Acces.md
@@ -73,6 +73,7 @@ The role has an inline policy granting:
 
 1. Deploy this template in your AWS account
 2. Provide the resulting role ARN, SQS queue ARN, and external ID to Cribl Cloud
+    2a. If you use AWS KMS Key encryption for your VPC Flow logs in S3, update the KMS Key policy in the Logging Account to allow Cribl Cloud to decrypt the VPC Flow logs in S3 by deploying the CloudFormation templatte (cribl_kms_key_policy_update.yaml) in your AWS Account that manages your KMS Key for your VPC Flow logs in S3
 3. Configure Cribl Cloud to use these credentials for accessing your VPC Flow logs
 
 This setup enables Cribl Cloud to securely access and process your VPC Flow logs, facilitating advanced log analysis and management capabilities.

--- a/templates/s3bucketcollection/template/cribl_kms_key_policy_update.yaml
+++ b/templates/s3bucketcollection/template/cribl_kms_key_policy_update.yaml
@@ -1,0 +1,122 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to update an existing AWS KMS Key policy for Cribl CloudTrail integration. Deploy this template directly in the AWS account that manages the KMS key.
+
+Parameters:
+  KMSKeyArn:
+    Description: ARN of the existing AWS KMS Key used by CloudTrail.
+    Type: String
+  CriblTrustCloudRoleArn:
+    Description: ARN of the CriblTrustCloud IAM Role that will be used to access the KMS Key.
+    Type: String
+  S3BucketName:
+    Description: Name of the S3 bucket that uses the KMS Key for encryption of the logs (e.g. centralized CloudTrail/VPC Flow logs S3 bucket name).
+    Type: String
+
+Resources:
+  UpdateKMSKeyPolicyFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: python3.9
+      Timeout: 300
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+          import json
+          import traceback
+
+          def handler(event, context):
+              kms = boto3.client('kms')
+              try:
+                  if event['RequestType'] in ['Create', 'Update']:
+                      key_arn = event['ResourceProperties']['KMSKeyArn']
+                      cribl_role_arn = event['ResourceProperties']['CriblTrustCloudRoleArn']
+                      # Extract account ID from CriblTrustCloudRoleArn
+                      # ARN format: arn:aws:iam::123456789012:role/CriblTrustCloud
+                      account_id = cribl_role_arn.split(":")[4]
+                      s3_bucket_name = event['ResourceProperties']['S3BucketName']
+
+                      # Get current policy
+                      key_id = key_arn.split('/')[-1]
+                      current_policy = kms.get_key_policy(KeyId=key_id, PolicyName='default')['Policy']
+                      policy_doc = json.loads(current_policy)
+
+                      # Add statements if not present
+                      new_statements = [
+                          {
+                              "Sid": "Allow Cribl IAM role to decrypt",
+                              "Effect": "Allow",
+                              "Principal": {"AWS": cribl_role_arn},
+                              "Action": ["kms:Decrypt", "kms:DescribeKey"],
+                              "Resource": "*"
+                          },
+                          {
+                              "Sid": "Allow S3 to use the key",
+                              "Effect": "Allow",
+                              "Principal": {"Service": "s3.amazonaws.com"},
+                              "Action": ["kms:GenerateDataKey", "kms:Decrypt"],
+                              "Resource": "*",
+                              "Condition": {
+                                  "StringEquals": {
+                                      "aws:SourceAccount": account_id
+                                  },
+                                  "ArnLike": {
+                                      "aws:SourceArn": f"arn:aws:s3:::{s3_bucket_name}"
+                                  }
+                              }
+                          }
+                      ]
+                      # Remove existing statements with same Sid
+                      policy_doc['Statement'] = [
+                          s for s in policy_doc['Statement']
+                          if s.get('Sid') not in [ns['Sid'] for ns in new_statements]
+                      ] + new_statements
+
+                      kms.put_key_policy(
+                          KeyId=key_id,
+                          PolicyName='default',
+                          Policy=json.dumps(policy_doc)
+                      )
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as e:
+                  print(str(e))
+                  traceback.print_exc()
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {})
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: KMSPolicyUpdate
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - kms:GetKeyPolicy
+                  - kms:PutKeyPolicy
+                Resource: !Ref KMSKeyArn
+
+  UpdateKMSKeyPolicyCustom:
+    Type: Custom::UpdateKMSKeyPolicy
+    Properties:
+      ServiceToken: !GetAtt UpdateKMSKeyPolicyFunction.Arn
+      KMSKeyArn: !Ref KMSKeyArn
+      CriblTrustCloudRoleArn: !Ref CriblTrustCloudRoleArn
+      S3BucketName: !Ref S3BucketName
+
+Outputs:
+  UpdatedKMSKeyArn:
+    Description: The ARN of the updated KMS Key
+    Value: !Ref KMSKeyArn

--- a/templates/s3bucketcollection/template/existing_cloudtrail_s3_trust.yaml
+++ b/templates/s3bucketcollection/template/existing_cloudtrail_s3_trust.yaml
@@ -1,18 +1,27 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Template to create an IAM role for Cribl Cloud Search and Stream to access an existing CloudTrail S3 bucket
 Parameters:
-  CloudTrailsS3:
-    Description: Existing AWS S3 bucket for CloudTrail Logs. You can use the aws cli command 'aws_cli % aws cloudtrail describe-trails | grep LogDestination' and select the S3 bucket. 
+  CloudTrailS3:
+    Description: Existing AWS S3 bucket name for CloudTrail Logs. You can use the aws cli command 'aws_cli % aws cloudtrail describe-trails | grep LogDestination' and select the S3 bucket. 
     Type: String
     Default: ''
   CTSQS:
-    Description: Name of the SQS queue for CloudTrail to trigger for S3 log retrieval.
+    Description: Name of the Amazon SQS queue for CloudTrail to trigger for S3 log retrieval.
     Type: String
     Default: cribl-cloudtrail-sqs
   CriblCloudAccountID:
     Description: Cribl Cloud Trust AWS Account ID. Navigate to Cribl.Cloud, go to Workspace and click on Access. Find the Trust and copy the AWS Account ID found in the trust ARN.
     Type: String
     Default: '012345678910'
+  KMSKeyArn:
+    Description: >
+      (Optional) ARN of the AWS KMS key used to encrypt CloudTrail logs in S3.
+      You can find your KMS Key Arn from the CloudTrail console in the Logging Account under Trails section and click on the trail name.
+    Type: String
+    Default: ''
+
+Conditions:
+  HasKMSKey: !Not [ !Equals [ !Ref KMSKeyArn, '' ] ]
 Resources:
   CriblCTQueue:
     Type: 'AWS::SQS::Queue'
@@ -35,6 +44,109 @@ Resources:
                   - !Ref AWS::AccountId
       Queues:
         - !Ref CTSQS
+        
+  # This is an inline configuration for the S3 bucket notification
+  # It will be applied to the existing bucket
+  CloudTrailBucketNotificationConfig:
+    Type: Custom::S3BucketNotification
+    DependsOn: 
+      - CriblCTQueuePolicy
+    Properties:
+      ServiceToken: !GetAtt S3NotificationFunction.Arn
+      BucketName: !Ref CloudTrailS3
+      NotificationConfiguration:
+        QueueConfigurations:
+          - Events:
+              - 's3:ObjectCreated:Put'
+            QueueArn: !GetAtt CriblCTQueue.Arn
+
+  # Lambda function to handle S3 bucket notification configuration
+  S3NotificationFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: python3.9
+      Timeout: 300
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+          import traceback
+          
+          def handler(event, context):
+              s3 = boto3.client('s3')
+              try:
+                  if event['RequestType'] in ['Create', 'Update']:
+                      bucket_name = event['ResourceProperties']['BucketName']
+                      notification_config = event['ResourceProperties']['NotificationConfiguration']
+                      s3.put_bucket_notification_configuration(
+                          Bucket=bucket_name,
+                          NotificationConfiguration=notification_config
+                      )
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as e:
+                  print(str(e))
+                  traceback.print_exc()
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {})
+
+  # IAM role for the Lambda function
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: S3NotificationPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:PutBucketNotification'
+                Resource: !Sub 'arn:aws:s3:::${CloudTrailS3}'
+
+  # Note: The AWS KMS kKey policy should be updated in the AWS Account that manages your KMS Key that was used to encrypt your CloudTrail data to include the following statements:
+  # {
+  #   "Sid": "Allow Cribl IAM role to decrypt",
+  #   "Effect": "Allow",
+  #   "Principal": {
+  #     "AWS": "[CriblTrustCloud.Arn]"
+  #   },
+  #   "Action": [
+  #     "kms:Decrypt",
+  #     "kms:DescribeKey"
+  #   ],
+  #   "Resource": "*"
+  # },
+  # {
+  #   "Sid": "Allow S3 to use the key",
+  #   "Effect": "Allow",
+  #   "Principal": {
+  #     "Service": "s3.amazonaws.com"
+  #   },
+  #   "Action": [
+  #     "kms:GenerateDataKey",
+  #     "kms:Decrypt"
+  #   ],
+  #   "Resource": "*",
+  #   "Condition": {
+  #     "StringEquals": {
+  #       "aws:SourceAccount": "[Logging-Account-ID]"
+  #     },
+  #     "ArnLike": {
+  #       "aws:SourceArn": "arn:aws:s3:::[CloudTrail-S3-Bucket-Name]"
+  #     }
+  #   }
+  # }
+
   CriblTrustCloud:
     Type: AWS::IAM::Role
     Properties:
@@ -74,8 +186,16 @@ Resources:
                   - 's3:PutObject'
                   - 's3:GetBucketLocation'
                 Resource:
-                  - !Sub "arn:aws:s3:::${CloudTrailsS3}"
-                  - !Sub "arn:aws:s3:::${CloudTrailsS3}/*"             
+                  - !Sub "arn:aws:s3:::${CloudTrailS3}"
+                  - !Sub "arn:aws:s3:::${CloudTrailS3}/*"
+              - !If
+                - HasKMSKey
+                - Effect: Allow
+                  Action:
+                    - 'kms:Decrypt'
+                    - 'kms:DescribeKey'
+                  Resource: !Ref KMSKeyArn
+                - !Ref 'AWS::NoValue'
               - Effect: Allow
                 Action: 
                   - sqs:ReceiveMessage
@@ -86,9 +206,9 @@ Resources:
                 Resource: 
                   - !GetAtt CriblCTQueue.Arn
 Outputs:
-  CloudTrailsS3:
+  CloudTrailS3:
     Description: CloudTrail S3 bucket
-    Value: !Ref CloudTrailsS3
+    Value: !Ref CloudTrailS3
   CTSQS:
     Description: SQS Queue for CloudTrail Logs
     Value: !GetAtt CriblCTQueue.Arn

--- a/templates/s3bucketcollection/template/existing_vpc_s3_trust.yaml
+++ b/templates/s3bucketcollection/template/existing_vpc_s3_trust.yaml
@@ -2,17 +2,26 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Template to create an IAM role for Cribl Cloud Search and Stream to access an existing VPC Flow S3 bucket
 Parameters:
   VPCFlowS3:
-    Description: Existing AWS S3 bucket for VPC Flow Logs. You can use the aws cli command 'aws_cli % aws cloudtrail describe-trails | grep LogDestination' and select the S3 bucket. 
+    Description: Existing AWS S3 bucket name for the VPC Flow Logs. 
     Type: String
     Default: ''
   VPCSQS:
-    Description: Name of the SQS queue for CloudTrail to trigger for S3 log retrieval.
+    Description: Name of the Amazon SQS queue for VPC Flow Logs to trigger for S3 log retrieval.
     Type: String
-    Default: cribl-vpc-sqs
+    Default: cribl-vpc-flow-logs-sqs
   CriblCloudAccountID:
     Description: Cribl Cloud Trust AWS Account ID. Navigate to Cribl.Cloud, go to Workspace and click on Access. Find the Trust and copy the AWS Account ID found in the trust ARN.
     Type: String
     Default: '012345678910'
+  KMSKeyArn:
+    Description: >
+      (Optional) ARN of the AWS KMS key used to encrypt CloudTrail logs in S3.
+      You can find your KMS Key Arn from the CloudTrail console in the Logging Account under Trails section and click on the trail name.
+    Type: String
+    Default: ''
+
+Conditions:
+  HasKMSKey: !Not [ !Equals [ !Ref KMSKeyArn, '' ] ]
 Resources:
   CriblVPCQueue:
     Type: 'AWS::SQS::Queue'
@@ -35,6 +44,109 @@ Resources:
                   - !Ref AWS::AccountId
       Queues:
         - !Ref VPCSQS
+        
+  # This is an inline configuration for the S3 bucket notification
+  # It will be applied to the existing bucket
+  CloudTrailBucketNotificationConfig:
+    Type: Custom::S3BucketNotification
+    DependsOn: 
+      - CriblVPCQueuePolicy
+    Properties:
+      ServiceToken: !GetAtt S3NotificationFunction.Arn
+      BucketName: !Ref VPCFlowS3
+      NotificationConfiguration:
+        QueueConfigurations:
+          - Events:
+              - 's3:ObjectCreated:Put'
+            QueueArn: !GetAtt CriblVPCQueue.Arn
+
+  # Lambda function to handle S3 bucket notification configuration
+  S3NotificationFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: python3.9
+      Timeout: 300
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+          import traceback
+          
+          def handler(event, context):
+              s3 = boto3.client('s3')
+              try:
+                  if event['RequestType'] in ['Create', 'Update']:
+                      bucket_name = event['ResourceProperties']['BucketName']
+                      notification_config = event['ResourceProperties']['NotificationConfiguration']
+                      s3.put_bucket_notification_configuration(
+                          Bucket=bucket_name,
+                          NotificationConfiguration=notification_config
+                      )
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as e:
+                  print(str(e))
+                  traceback.print_exc()
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {})
+
+  # IAM role for the Lambda function
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: S3NotificationPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:PutBucketNotification'
+                Resource: !Sub 'arn:aws:s3:::${VPCFlowS3}'
+
+  # Note: The AWS KMS kKey policy should be updated in the AWS Account that manages your KMS Key that was used to encrypt your CloudTrail data to include the following statements:
+  # {
+  #   "Sid": "Allow Cribl IAM role to decrypt",
+  #   "Effect": "Allow",
+  #   "Principal": {
+  #     "AWS": "[CriblTrustCloud.Arn]"
+  #   },
+  #   "Action": [
+  #     "kms:Decrypt",
+  #     "kms:DescribeKey"
+  #   ],
+  #   "Resource": "*"
+  # },
+  # {
+  #   "Sid": "Allow S3 to use the key",
+  #   "Effect": "Allow",
+  #   "Principal": {
+  #     "Service": "s3.amazonaws.com"
+  #   },
+  #   "Action": [
+  #     "kms:GenerateDataKey",
+  #     "kms:Decrypt"
+  #   ],
+  #   "Resource": "*",
+  #   "Condition": {
+  #     "StringEquals": {
+  #       "aws:SourceAccount": "[Logging-Account-ID]"
+  #     },
+  #     "ArnLike": {
+  #       "aws:SourceArn": "arn:aws:s3:::[CloudTrail-S3-Bucket-Name]"
+  #     }
+  #   }
+  # }
+
   CriblTrustCloud:
     Type: AWS::IAM::Role
     Properties:
@@ -75,7 +187,15 @@ Resources:
                   - 's3:GetBucketLocation'
                 Resource:
                   - !Sub "arn:aws:s3:::${VPCFlowS3}"
-                  - !Sub "arn:aws:s3:::${VPCFlowS3}/*"             
+                  - !Sub "arn:aws:s3:::${VPCFlowS3}/*"
+              - !If
+                - HasKMSKey
+                - Effect: Allow
+                  Action:
+                    - 'kms:Decrypt'
+                    - 'kms:DescribeKey'
+                  Resource: !Ref KMSKeyArn
+                - !Ref 'AWS::NoValue'
               - Effect: Allow
                 Action: 
                   - sqs:ReceiveMessage
@@ -87,10 +207,10 @@ Resources:
                   - !GetAtt CriblVPCQueue.Arn
 Outputs:
   VPCFlowS3:
-    Description: VPC Flow Log S3 bucket
+    Description: CloudTrail S3 bucket
     Value: !Ref VPCFlowS3
   VPCSQS:
-    Description: SQS Queue for VPC Flow Logs
+    Description: SQS Queue for CloudTrail Logs
     Value: !GetAtt CriblVPCQueue.Arn
   RoleName:
     Description: Name of created IAM Role

--- a/templates/s3bucketcollection/template/kms_key_policy_sample.json
+++ b/templates/s3bucketcollection/template/kms_key_policy_sample.json
@@ -1,0 +1,34 @@
+[
+    {
+        "Sid": "Allow Cribl IAM role to decrypt",
+        "Effect": "Allow",
+        "Principal": {
+            "AWS": "[CriblTrustCloud.Arn]"
+        },
+        "Action": [
+            "kms:Decrypt",
+            "kms:DescribeKey"
+        ],
+        "Resource": "*"
+    },
+    {
+        "Sid": "Allow S3 to use the key",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "s3.amazonaws.com"
+        },
+        "Action": [
+            "kms:GenerateDataKey",
+            "kms:Decrypt"
+        ],
+        "Resource": "*",
+        "Condition": {
+            "StringEquals": {
+                "aws:SourceAccount": "[Logging-Account-ID]"
+            },
+            "ArnLike": {
+                "aws:SourceArn": "arn:aws:s3:::[CloudTrail-S3-Bucket-Name]"
+            }
+        }
+    }
+]


### PR DESCRIPTION
Fixes to allow CloudTrail and VPC FLow Logs in existing S3 buckets to be ingested to Cribl Cloud through SQS Queue and S3 event notifications and allowing for correct decryption if using AWS KMS customer managed keys