### PR TITLE
Updated IAM Role Policy for AWS API for Search

### DIFF
--- a/templates/s3bucketcollection/template/cribl_cloud_trust.yaml
+++ b/templates/s3bucketcollection/template/cribl_cloud_trust.yaml
@@ -58,6 +58,53 @@ Resources:
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
                 Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - ec2:DescribeInstances
+                  - ec2:DescribeVolumes
+                  - ec2:DescribeSecurityGroups
+                Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - lambda:ListFunctions
+                Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - iam:ListRoles
+                  - iam:ListUsers
+                  - iam:ListGroups
+                  - iam:ListPolicies
+                  - iam:ListMFADevices
+                Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - cloudformation:ListExports
+                  - cloudformation:ListStacks
+                  - cloudformation:ListStackSets
+                Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - dynamodb:ListBackups
+                Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - dynamodb:ListTables
+                Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - rds:DescribeDBInstances
+                  - rds:DescribeDBClusterEndpoints
+                  - rds:DescribeDBSecurityGroups
+                  - rds:DescribeCertificates
+                  - rds:DescribeDBClusters
+              - Effect: Allow
+                Action: 
+                  - cloudtrail:LookupEvents
+                Resource: '*'
+              - Effect: Allow
+                Action: 
+                  - elasticfilesystem:DescribeFileSystems 
+                Resource: '*'
 Outputs:
   RoleName:
     Description: Name of created IAM Role


### PR DESCRIPTION
Updated IAM Role Policy to include Cribl Search AWS API services.
Link to the docs with the IAM Policy https://docs.cribl.io/search/set-up-aws#permission-requirements-for-aws-api 